### PR TITLE
Allow user to set endSeconds from json

### DIFF
--- a/player.js
+++ b/player.js
@@ -59,6 +59,7 @@ class YoutubePlayer {
     this.controller = parentController;
     this.track = track;
     this.startTime = startTime;
+    this.endTime = track.endSeconds;
     this.pollTimer = false;
     this.id = false;
     this.trackError = false;
@@ -72,7 +73,7 @@ class YoutubePlayer {
   onPlayerReady() {
     this.ready = true;
     if (this.track) {
-      this.setTrack(this.track.id, this.startTime);
+      this.setTrack(this.track.id, this.startTime, this.endTime);
     }
   }
 
@@ -139,13 +140,24 @@ class YoutubePlayer {
   pause() {
     this.player.pauseVideo();
   }
-  setTrack(id, startingTime) {
+  setTrack(id, startingTime, endingTime) {
     // hack to make html5 player work
     setTimeout(() => {
-      this.player.loadVideoById({
-        videoId: id,
-        startSeconds: startingTime,
-      });
+      if (endingTime > 0) {
+        // endingTime > 0 will be added to endSeconds loadVideoById.
+        this.player.loadVideoById({
+          videoId: id,
+          startSeconds: startingTime,
+          endSeconds: endingTime
+        });
+      } else {
+        // Otherwise will behave as normal.
+        this.player.loadVideoById({
+          videoId: id,
+          startSeconds: startingTime
+        });
+      }
+
       this.player.setVolume(this.controller.volume);
       this.play();
     }, 10);

--- a/poeCustomSoundtrack.js
+++ b/poeCustomSoundtrack.js
@@ -83,6 +83,7 @@ function generateTrack(track) {
     type,
     id,
     name: track.name,
+    endSeconds: track.endSeconds // Optional ending time in seconds to loop earlier.
   };
 }
 


### PR DESCRIPTION
Sometimes, videos do not loop properly due to marketing stuff at the end of the videos, youtube timestamp errors, or the actual videos themselves ending in the middle of the loop.

This change allows users to add an optional endSeconds to the json file to get around these problems. As this is optional, it should not affect existing json. Let me know what you think.

Example:

`{
            "name": "login",
            "location": "https://www.youtube.com/watch?v=7Ew6GgduOE4",
            "endSeconds": 156
        }`