### PR TITLE
Zone transition check track ID instead of track name.

### DIFF
--- a/poeCustomSoundtrack.js
+++ b/poeCustomSoundtrack.js
@@ -13,6 +13,7 @@ const settings = require('electron-settings');
 
 let mainWindow;
 let currentTrackName = false;
+let currentTrackId = false;
 let ft;
 let isUpdateAvailable = false;
 let isUpdateDownloading = false;
@@ -23,6 +24,7 @@ let soundtrack = defaults.soundtrack;
 
 function reset(){
   currentTrackName = false;
+  currentTrackId = false;
 }
 
 function updateRunningStatus(){
@@ -87,7 +89,23 @@ function generateTrack(track) {
 }
 
 function randomElement(arr) {
-  return arr ? arr[Math.floor(Math.random() * arr.length)] : false;
+  
+  // Array with more than 1 unique track ID always change track.
+
+  // Find tracks other than current track.
+  const otherTrackArr = arr.filter(t => getTrackId(t.location) !== currentTrackId);
+  
+  if (otherTrackArr.length === 0) {
+    // No other tracks.
+    // Reuse current track.
+    return arr ? arr[0] : false;
+  } else {
+    // Has other tracks.
+    // Exclude current track and pick a random track.
+    return otherTrackArr ? otherTrackArr[Math.floor(Math.random() * otherTrackArr.length)] : false;
+  }
+  
+  //return arr ? arr[Math.floor(Math.random() * arr.length)] : false;
 }
 
 function getTrack(areaName) {
@@ -106,8 +124,9 @@ function getTrack(areaName) {
   return track;
 }
 
-
-function parseLogLine(line) {
+// Changed to async to prevent double playing in login screen
+async function parseLogLine(line) {
+  
 
   //assume POE is running if a new log line come sin
   isPoERunning = true;
@@ -122,7 +141,7 @@ function parseLogLine(line) {
   const exitWindow = line.match(/] Async connecting to /)
     || line.match(/] Abnormal disconnect: An unexpected disconnection occurred./);
   
-    if (loginWindow || exitWindow) {
+  if (loginWindow || exitWindow) {
     newArea = ['login', 'login'];
   }
   
@@ -130,9 +149,17 @@ function parseLogLine(line) {
     const areaCode = newArea[1];
     const track = getTrack(areaCode);
     if (track) {
-      if (currentTrackName !== track.name) {
+      if (areaCode === 'login' && currentTrackName !== track.name // Login screen uses existing logic
+          || areaCode !== 'login' && currentTrackId !== track.id) { // Zone transition checks track ID instead of track names
         currentTrackName = track.name;
+        currentTrackId = track.id;
         mainWindow.webContents.send('changeTrack', track);
+      }
+
+      // Prevent double playing in login screen as currentTrackName may be late to update
+      while (areaCode === 'login' && currentTrackName !== track.name) {
+        // Wait until currentTrackName is updated
+        await new Promise(resolve => setTimeout(resolve, 100));
       }
     }
   }


### PR DESCRIPTION
In playlists where you have many track IDs under the same name, and/or you have many adjacent zones with the same names, the track currently won't change. [This soundtrack file](https://www.dropbox.com/scl/fo/76bggwer7uzyk9ta90ap4/ANNC0FrkI-UubsYfjTWwAHM?e=1&preview=the_elder_scrolls_3_morrowind_324.soundtrack&rlkey=p1zw2stmkplmbbqcg90hw3of2) I found is a good example.

This change adds variety by checking track ID instead of track name.

